### PR TITLE
feat: add github graphql implementation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+artifacts/
+node_modules/
+features/*.feature

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,1 @@
+extends: screwdriver

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+artifacts/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2016 Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Yahoo Inc.
+Copyright 2024 Yahoo Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Required parameters:
 | schema     | Object | The schema object |
 | schema.slug     | String | The github enterprise slug |
 | schema.username      | String | The github user's login name |
-| schema.token | String | some_token | The github token to interact with the graphql api |
+| schema.token | String | The github token to interact with the graphql api |
 
 #### Expected Outcome
 
@@ -45,7 +45,7 @@ Required parameters:
 | :-------------   | :---- | :-------------|
 | schema     | Object | The schema object |
 | schema.slug     | String | The github enterprise slug |
-| schema.token | String | some_token | The github token to interact with the graphql api |
+| schema.token | String | The github token to interact with the graphql api |
 
 #### Expected Outcome
 
@@ -58,7 +58,7 @@ Required parameters:
 | :-------------   | :---- | :-------------|
 | schema     | Object | The schema object |
 | schema.login     | String | The github user's login name |
-| schema.token | String | some_token | The github token to interact with the graphql api |
+| schema.token | String | The github token to interact with the graphql api |
 
 ##### Expected Outcome
 Returns the github user based on schema https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#user

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Required parameters:
 | :-------------   | :---- | :-------------|
 | schema     | Object | The schema object |
 | schema.slug     | String | The github enterprise slug |
-| schema.username      | String | The github user's login name |
+| schema.login      | String | The github user's login name |
 | schema.token | String | The github token to interact with the graphql api |
 
 #### Expected Outcome

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
 # scm-github-graphql
-Module to query github graphql api
+[![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] ![License][license-image]
+
+## Usage
+
+```bash
+npm install screwdriver-scm-github-graphql
+```
+
+### Initialization
+
+The class interacts with (GitHub GraphQL API)[https://docs.github.com/en/enterprise-cloud@latest/graphql/overview/about-the-graphql-api]
+The following configuration is needed
+
+| Parameter        | Type  |  Default | Description |
+| :-------------   | :---- | :-------------| :-------------|
+| config        | Object | | Configuration Object |
+| config.graphQlUrl | String | https://api.github.com/graphql | Github GraphQL API Endpoint |
+```js
+const scm = new GithubScmGraphQL({
+    graphQlUrl: 'https://api.github.com/graphql'
+});
+```
+
+### Methods
+
+#### getEnterpriseUserAccount
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| schema     | Object | The schema object |
+| schema.slug     | String | The github enterprise slug |
+| schema.username      | String | The github user's login name |
+| schema.token | String | some_token | The github token to interact with the graphql api |
+
+#### Expected Outcome
+
+Gets the enterprise user account based on schema https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
+
+#### listEnterpriseMembers
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| schema     | Object | The schema object |
+| schema.slug     | String | The github enterprise slug |
+| schema.token | String | some_token | The github token to interact with the graphql api |
+
+#### Expected Outcome
+
+This method retrieves a list of enterprise members based on schema https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/unions#enterprisemember.
+
+##### getUser
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| schema     | Object | The schema object |
+| schema.login     | String | The github user's login name |
+| schema.token | String | some_token | The github token to interact with the graphql api |
+
+##### Expected Outcome
+Returns the github user based on schema https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#user
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[npm-image]: https://img.shields.io/npm/v/screwdriver-scm-github-graphql.svg
+[npm-url]: https://npmjs.org/package/screwdriver-scm-github-graphql
+[downloads-image]: https://img.shields.io/npm/dt/screwdriver-scm-github-graphql.svg
+[license-image]: https://img.shields.io/npm/l/screwdriver-scm-github-graphql.svg
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver.svg
+[issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
+[status-image]: https://cd.screwdriver.cd/pipelines/13562/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/13562

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const queries = require('./queries');
 class GithubScmGraphQL {
     /**
      * constructor
-     * @param {Object} config
+     * @param {Object} config            The config object
      * @param {String} config.graphQlUrl The graphql url
      */
     constructor(config) {
@@ -19,16 +19,16 @@ class GithubScmGraphQL {
      * Gets the enterprise user account schema
      * @param {String} config              The config object
      * @param {String} config.slug         The github enterprise slug
-     * @param {String} config.username     The github username
-     * @param {String} config.token             Access token
+     * @param {String} config.login        The github user login
+     * @param {String} config.token        The access token
      * @returns Object https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
      */
     async getEnterpriseUserAccount(config) {
-        const { slug, username, token } = config;
+        const { slug, login, token } = config;
 
         const { data } = await this.sdGql.query({
             query: queries.GetEnterpriseUserAccount,
-            variables: { slug, query: username },
+            variables: { slug, query: login },
             token
         });
 
@@ -45,9 +45,9 @@ class GithubScmGraphQL {
 
     /**
      * Helper method to paginate the enterprise members recursively
-     * @param {*} slug
-     * @param {*} cursor
-     * @param {*} members
+     * @param {*} config   The config object
+     * @param {*} cursor   The current page
+     * @param {*} members  The list of members
      * @returns Array https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/unions#enterprisemember
      */
     async _listEnterpriseMembersHelper(config, cursor, allMembers = []) {
@@ -75,8 +75,9 @@ class GithubScmGraphQL {
 
     /**
      * List of enterprise members schema
-     * @param {String} config      The config object
-     * @param {String} config.slug The github enterprise slug
+     * @param {String} config       The config object
+     * @param {String} config.slug  The github enterprise slug
+     * @param {String} config.token The access token
      * @returns Array https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/unions#enterprisemember
      */
     async listEnterpriseMembers(config) {
@@ -85,9 +86,9 @@ class GithubScmGraphQL {
 
     /**
      * Gets the the github user schema
-     * @param {Object} config             Config object
-     * @param {String} config.login     Github username
-     * @param {String} config.toke      Access token
+     * @param {Object} config             The config object
+     * @param {String} config.login       The github user login
+     * @param {String} config.toke        The access token
      * @returns Object https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#user
      * or https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
      */

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class GithubScmGraphQL {
      * @param {String} config              The config object
      * @param {String} config.slug         The github enterprise slug
      * @param {String} config.username     The github username
+     * @param {String} config.token             Access token
      * @returns Object https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
      */
     async getEnterpriseUserAccount(config) {
@@ -84,8 +85,9 @@ class GithubScmGraphQL {
 
     /**
      * Gets the the github user schema
-     * @param {String} config    The config object
-     * @param {String} login     The github username
+     * @param {Object} config             Config object
+     * @param {String} config.login     Github username
+     * @param {String} config.toke      Access token
      * @returns Object https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#user
      * or https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
      */

--- a/index.js
+++ b/index.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const SDGraphQLClient = require('./sd-graphql');
+const queries = require('./queries');
+
+class GithubScmGraphQL {
+    /**
+     * constructor
+     * @param {Object} config
+     * @param {String} config.graphQlUrl The graphql url
+     */
+    constructor(config) {
+        this.sdGql = new SDGraphQLClient({
+            graphqlUrl: config.graphQlUrl || 'https://api.github.com/graphql'
+        });
+    }
+
+    /**
+     * Gets the enterprise user account schema
+     * @param {String} config              The config object
+     * @param {String} config.slug         The github enterprise slug
+     * @param {String} config.username     The github username
+     * @returns Object https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
+     */
+    async getEnterpriseUserAccount(config) {
+        const { slug, username, token } = config;
+
+        const { data } = await this.sdGql.query({
+            query: queries.GetEnterpriseUserAccount,
+            variables: { slug, query: username },
+            token
+        });
+
+        if (data && data.enterprise) {
+            const { members } = data.enterprise;
+
+            if (members && members.totalCount === 1) {
+                return members.nodes[0];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Helper method to paginate the enterprise members recursively
+     * @param {*} slug
+     * @param {*} cursor
+     * @param {*} members
+     * @returns Array https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/unions#enterprisemember
+     */
+    async _listEnterpriseMembersHelper(config, cursor, allMembers = []) {
+        const { slug, token } = config;
+
+        const { data } = await this.sdGql.query({
+            query: queries.ListEnterpriseMembers,
+            variables: { slug, cursor },
+            token
+        });
+
+        if (data && data.enterprise && data.enterprise.members) {
+            const { nodes, pageInfo } = data.enterprise.members;
+
+            if (nodes) {
+                allMembers.push(...nodes);
+            }
+            if (pageInfo && pageInfo.hasNextPage) {
+                return this._listEnterpriseMembersHelper(config, pageInfo.endCursor, allMembers);
+            }
+        }
+
+        return allMembers;
+    }
+
+    /**
+     * List of enterprise members schema
+     * @param {String} config      The config object
+     * @param {String} config.slug The github enterprise slug
+     * @returns Array https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/unions#enterprisemember
+     */
+    async listEnterpriseMembers(config) {
+        return this._listEnterpriseMembersHelper(config, null, []);
+    }
+
+    /**
+     * Gets the the github user schema
+     * @param {String} config    The config object
+     * @param {String} login     The github username
+     * @returns Object https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#user
+     * or https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/objects#enterpriseuseraccount
+     */
+    async getUser(config) {
+        const { login, token } = config;
+        const { data } = await this.sdGql.query({
+            query: queries.GetUser,
+            variables: { login },
+            token
+        });
+
+        return data.user;
+    }
+}
+
+module.exports = GithubScmGraphQL;

--- a/mocha.config.json
+++ b/mocha.config.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec, mocha-sonarqube-reporter",
+    "mochaSonarqubeReporterReporterOptions": {
+        "output": "./artifacts/report/test.xml"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "screwdriver-scm-github-graphql",
+  "version": "1.0.0",
+  "description": "Github GraphQL SCM for Screwdriver",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "eslint .",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/screwdriver-cd/scm-github-graphql.git"
+  },
+  "homepage": "https://github.com/screwdriver-cd/scm-github-graphql",
+  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
+  "keywords": [
+    "screwdriver",
+    "yahoo"
+  ],
+  "license": "BSD-3-Clause",
+  "author": "Pritam Paul <pritamstyz4ever@gmail.com>",
+  "contributors": [],
+  "devDependencies": {
+    "chai": "^4.3.6",
+    "eslint": "^7.32.0",
+    "eslint-config-screwdriver": "^5.0.1",
+    "mocha": "^10.3.0",
+    "mocha-multi-reporters": "^1.5.1",
+    "mocha-sonarqube-reporter": "^1.0.2",
+    "nyc": "^15.0.0",
+    "sinon": "^9.0.0"
+  },
+  "dependencies": {
+    "graphql-tag": "^2.12.6",
+    "rewire": "^7.0.0",
+    "rewiremock": "^3.14.5",
+    "screwdriver-request": "^2.0.1"
+  },
+  "release": {
+    "debug": false
+  }
+}

--- a/queries.js
+++ b/queries.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const gql = require('graphql-tag');
+
+module.exports.GetEnterpriseUserAccount = gql`
+    query GetEnterpriseUserAccount($slug: String!, $query: String!) {
+        enterprise(slug: $slug) {
+            name
+            id
+            members(query: $query, first: 1, role: MEMBER) {
+                totalCount
+                nodes {
+                    type: __typename
+                    ... on EnterpriseUserAccount {
+                        id
+                        name
+                        login
+                    }
+                    ... on User {
+                        id
+                        name
+                        login
+                    }
+                }
+            }
+        }
+    }
+`;
+
+module.exports.ListEnterpriseMembers = gql`
+    query ListEnterpriseMembers($slug: String!, $cursor: String) {
+        enterprise(slug: $slug) {
+            name
+            id
+            members(first: 100, role: MEMBER, after: $cursor) {
+                totalCount
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    type: __typename
+                    ... on EnterpriseUserAccount {
+                        id
+                        name
+                        login
+                    }
+                    ... on User {
+                        id
+                        name
+                        login
+                    }
+                }
+            }
+            organizations(first: 100) {
+                totalCount
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    ... on Organization {
+                        name
+                        id
+                        login
+                    }
+                }
+            }
+        }
+    }
+`;
+
+module.exports.GetUser = gql`
+    query GetUser($login: String!) {
+        user(login: $login) {
+            name
+            id
+            enterprises(first: 100) {
+                totalCount
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    id
+                    name
+                    slug
+                }
+            }
+            organizations(first: 100) {
+                totalCount
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    id
+                    name
+                    login
+                }
+            }
+        }
+    }
+`;

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,20 @@
+shared:
+    image: node:18
+
+jobs:
+    main:
+        environment:
+            SD_SONAR_OPTS: "-Dsonar.sources=index.js -Dsonar.tests=test -Dsonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info -Dsonar.testExecutionReportPaths=artifacts/report/test.xml"
+        requires: [~pr, ~commit]
+        steps:
+            - install: npm install
+            - test: npm test
+
+    publish:
+        requires: [main]
+        template: screwdriver-cd/semantic-release
+        secrets:
+            # Publishing to NPM
+            - NPM_TOKEN
+            # Pushing tags to Git
+            - GH_TOKEN

--- a/sd-graphql/index.js
+++ b/sd-graphql/index.js
@@ -28,7 +28,7 @@ class SDGraphQLClient {
      * @param {String} schema              The schema object
      * @param {String} schema.query        The graphql query
      * @param {Object} schema.variables    The variables to use in the query
-     * @param {Object} schema.token        The token to use for authentication
+     * @param {String} schema.token        The token to use for authentication
      * @param {Object} schema.options      The options to pass to the request
      * @returns Promise
      */
@@ -56,7 +56,7 @@ class SDGraphQLClient {
      * @param {String} schema             The schema object
      * @param {String} schema.mutation    The graphql mutation
      * @param {Object} schema.variables   The variables to use in the mutation
-     * @param {Object} schema.token       The token to use for authentication
+     * @param {String} schema.token       The token to use for authentication
      * @param {Object} schema.options     The options to pass to the request
      * @returns Promise
      */

--- a/sd-graphql/index.js
+++ b/sd-graphql/index.js
@@ -57,7 +57,7 @@ class SDGraphQLClient {
      * @param {String} schema.mutation    The graphql mutation
      * @param {Object} schema.variables   The variables to use in the mutation
      * @param {Object} schema.token       The token to use for authentication
-     * @param {Object} options     The options to pass to the request
+     * @param {Object} schema.options     The options to pass to the request
      * @returns Promise
      */
     async mutate(schema) {

--- a/sd-graphql/index.js
+++ b/sd-graphql/index.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const request = require('screwdriver-request');
+
+/**
+ * Wrapper around screwdriver-request lib to make graphql requests
+ * @class
+ * @param {Object} config The config object
+ * @param {String} config.graphqlUrl The graphql url
+ * @param {String} config.token The token to use for authentication
+ * @example
+ * const client = new SDGraphQLClient({
+ *    graphqlUrl: 'https://api.github.com/graphql',
+ *    token: 'ghp_abcd12345'
+ * });
+ */
+class SDGraphQLClient {
+    /**
+     * @param {Object} config The config object
+     * @param {String} config.graphqlUrl The graphql url
+     */
+    constructor(config) {
+        this._config = config;
+    }
+
+    /**
+     * Run a graphql query and return the result
+     * @param {String} schema              The schema object
+     * @param {String} schema.query        The graphql query
+     * @param {Object} schema.variables    The variables to use in the query
+     * @param {Object} schema.token        The token to use for authentication
+     * @param {Object} schema.options      The options to pass to the request
+     * @returns Promise
+     */
+    async query(schema) {
+        const { query, variables, token, options } = schema;
+        const res = await request({
+            method: 'POST',
+            url: this._config.graphqlUrl,
+            context: {
+                token
+            },
+            json: JSON.stringify({ query, variables }),
+            ...options
+        });
+
+        if (res.body.errors) {
+            throw new Error(res.body.errors);
+        }
+
+        return res.body;
+    }
+
+    /**
+     * Run a graphql mutation and return the result
+     * @param {String} schema             The schema object
+     * @param {String} schema.mutation    The graphql mutation
+     * @param {Object} schema.variables   The variables to use in the mutation
+     * @param {Object} schema.token       The token to use for authentication
+     * @param {Object} options     The options to pass to the request
+     * @returns Promise
+     */
+    async mutate(schema) {
+        const { mutation, variables, token, options } = schema;
+        const res = await request({
+            method: 'POST',
+            url: this._config.graphqlUrl,
+            context: {
+                token
+            },
+            json: JSON.stringify({ mutation, variables }),
+            ...options
+        });
+
+        if (res.body.errors) {
+            throw new Error(res.body.errors);
+        }
+
+        return res.body;
+    }
+}
+
+module.exports = SDGraphQLClient;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const rewireMock = require('rewiremock/node');
+const queries = require('../queries');
+
+sinon.assert.expose(assert, {
+    prefix: ''
+});
+
+describe('GithubGraphQL', () => {
+    let githubGql;
+    let GithubScmGraphQL;
+    // let sdGqlMock;
+
+    const mockUser = {
+        type: 'User',
+        id: 'U_abcdef',
+        name: 'Cyborg',
+        login: 'cyborg'
+    };
+
+    const mockUser1 = {
+        type: 'EnterpriseUserAccount',
+        id: 'EUA_abcdef',
+        name: 'AI Humanoid',
+        login: 'ai_humanoid'
+    };
+    const mockUser2 = {
+        type: 'EnterpriseUserAccount',
+        id: 'EAU_abcd1234',
+        name: 'Human Being',
+        login: 'human_being'
+    };
+
+    const config = {
+        githubGraphQLUrl: 'https://api.github.com/graphql'
+    };
+    const token = 'ghp_abcdef';
+
+    before(() => {
+        // eslint-disable-next-line global-require
+        GithubScmGraphQL = require('../index');
+
+        class SDGraphQLClient {
+            constructor(cfg) {
+                this.config = cfg;
+            }
+        }
+
+        GithubScmGraphQL = rewireMock.proxy('../index', {
+            '../sd-graphql': SDGraphQLClient
+        });
+
+        githubGql = new GithubScmGraphQL(config);
+        githubGql.sdGql.query = sinon.stub();
+        githubGql.sdGql.mutate = sinon.stub();
+    });
+
+    it('should get enterprise user account', async () => {
+        const slug = 'slug';
+        const username = 'ai_humanoid';
+        const data = {
+            enterprise: {
+                members: {
+                    totalCount: 1,
+                    nodes: [mockUser1]
+                }
+            }
+        };
+
+        githubGql.sdGql.query.resolves({ data });
+
+        const result = await githubGql.getEnterpriseUserAccount({
+            slug,
+            username,
+            token
+        });
+
+        assert.deepEqual(result, data.enterprise.members.nodes[0]);
+        assert.calledWith(githubGql.sdGql.query, {
+            query: queries.GetEnterpriseUserAccount,
+            variables: { slug, query: username },
+            token
+        });
+    });
+
+    it('should return null if no enterprise user account', async () => {
+        const slug = 'slug';
+        const username = 'ai_humanoid';
+        const data = {
+            enterprise: {
+                members: {
+                    totalCount: 0
+                }
+            }
+        };
+
+        githubGql.sdGql.query.resolves({ data });
+
+        const result = await githubGql.getEnterpriseUserAccount({
+            slug,
+            username,
+            token
+        });
+
+        assert.equal(result, null);
+        assert.calledWith(githubGql.sdGql.query, {
+            query: queries.GetEnterpriseUserAccount,
+            variables: { slug, query: username },
+            token
+        });
+    });
+
+    it('should list enterprise members', async () => {
+        const slug = 'slug';
+
+        const data = {
+            enterprise: {
+                members: {
+                    totalCount: 2,
+                    nodes: [mockUser1, mockUser2],
+                    pageInfo: {
+                        hasNextPage: false
+                    }
+                }
+            }
+        };
+
+        githubGql.sdGql.query.resolves({ data });
+
+        const result = await githubGql.listEnterpriseMembers({
+            slug,
+            token
+        });
+
+        assert.deepEqual(result, [mockUser1, mockUser2]);
+        assert.calledWith(githubGql.sdGql.query, {
+            query: queries.ListEnterpriseMembers,
+            variables: { slug, cursor: null },
+            token
+        });
+    });
+
+    it('should list enterprise members with pagination', async () => {
+        const slug = 'slug';
+        const data1 = {
+            enterprise: {
+                members: {
+                    totalCount: 2,
+                    nodes: [mockUser1],
+                    pageInfo: {
+                        hasNextPage: true,
+                        endCursor: 'cursor1'
+                    }
+                }
+            }
+        };
+
+        const data2 = {
+            enterprise: {
+                members: {
+                    totalCount: 2,
+                    nodes: [mockUser2],
+                    pageInfo: {
+                        hasNextPage: false
+                    }
+                }
+            }
+        };
+
+        githubGql.sdGql.query = sinon.stub().resolves();
+
+        githubGql.sdGql.query
+            .onFirstCall()
+            .resolves({ data: data1 })
+            .onSecondCall()
+            .resolves({ data: data2 });
+
+        const result = await githubGql.listEnterpriseMembers({
+            slug,
+            token
+        });
+
+        assert.deepEqual(result, [mockUser1, mockUser2]);
+        assert.calledWith(githubGql.sdGql.query.firstCall, {
+            query: queries.ListEnterpriseMembers,
+            variables: { slug, cursor: null },
+            token
+        });
+        assert.calledWith(githubGql.sdGql.query.secondCall, {
+            query: queries.ListEnterpriseMembers,
+            variables: { slug, cursor: 'cursor1' },
+            token
+        });
+    });
+
+    it('should get the github user', async () => {
+        const login = 'ai_humanoid';
+        const data = {
+            user: mockUser
+        };
+
+        githubGql.sdGql.query.resolves({ data });
+
+        const result = await githubGql.getUser({
+            login,
+            token
+        });
+
+        assert.deepEqual(result, mockUser);
+        assert.calledWith(githubGql.sdGql.query, {
+            query: queries.GetUser,
+            variables: { login },
+            token
+        });
+    });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -59,7 +59,7 @@ describe('GithubGraphQL', () => {
 
     it('should get enterprise user account', async () => {
         const slug = 'slug';
-        const username = 'ai_humanoid';
+        const login = 'ai_humanoid';
         const data = {
             enterprise: {
                 members: {
@@ -73,21 +73,21 @@ describe('GithubGraphQL', () => {
 
         const result = await githubGql.getEnterpriseUserAccount({
             slug,
-            username,
+            login,
             token
         });
 
         assert.deepEqual(result, data.enterprise.members.nodes[0]);
         assert.calledWith(githubGql.sdGql.query, {
             query: queries.GetEnterpriseUserAccount,
-            variables: { slug, query: username },
+            variables: { slug, query: login },
             token
         });
     });
 
     it('should return null if no enterprise user account', async () => {
         const slug = 'slug';
-        const username = 'ai_humanoid';
+        const login = 'ai_humanoid';
         const data = {
             enterprise: {
                 members: {
@@ -100,14 +100,14 @@ describe('GithubGraphQL', () => {
 
         const result = await githubGql.getEnterpriseUserAccount({
             slug,
-            username,
+            login,
             token
         });
 
         assert.equal(result, null);
         assert.calledWith(githubGql.sdGql.query, {
             query: queries.GetEnterpriseUserAccount,
-            variables: { slug, query: username },
+            variables: { slug, query: login },
             token
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,7 +12,6 @@ sinon.assert.expose(assert, {
 describe('GithubGraphQL', () => {
     let githubGql;
     let GithubScmGraphQL;
-    // let sdGqlMock;
 
     const mockUser = {
         type: 'User',

--- a/test/sd-graphql.test.js
+++ b/test/sd-graphql.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('assert');
+const rewireMock = require('rewiremock/node');
+
+sinon.assert.expose(assert, {
+    prefix: ''
+});
+
+describe('SDGraphQLClient', () => {
+    let client;
+    let SDGraphQLClient;
+    let requestMock;
+
+    beforeEach(() => {
+        requestMock = sinon.stub();
+        SDGraphQLClient = rewireMock.proxy('../sd-graphql', {
+            'screwdriver-request': requestMock
+        });
+
+        client = new SDGraphQLClient({
+            graphqlUrl: 'https://api.ai.com/graphql',
+            token: 'ghp_abcdef'
+        });
+    });
+
+    it('should initialize SDGraphQLClient', () => {
+        // Test the initialization of SDGraphQLClient
+        assert.ok(client instanceof SDGraphQLClient);
+    });
+
+    it('should make a GraphQL query', async () => {
+        // Test making a GraphQL query using SDGraphQLClient
+        const query = `
+            query GetUser($username: String!) {
+                user(login: $username) {
+                    name
+                    email
+                    login
+                }
+            }
+        `;
+
+        const variables = {
+            username: 'ai_humanoid'
+        };
+
+        const expectedResponse = {
+            body: {
+                data: {
+                    user: {
+                        name: 'AI Humanoid',
+                        email: 'ai.humanoid@agi.com',
+                        login: 'ai_humanoid'
+                    }
+                }
+            }
+        };
+
+        requestMock.resolves(expectedResponse);
+
+        const response = await client.query(query, variables);
+
+        assert.ok(response);
+        assert.ok(response.data);
+        assert.ok(response.data.user);
+        assert.strictEqual(response.data.user.name, 'AI Humanoid');
+        assert.strictEqual(response.data.user.email, 'ai.humanoid@agi.com');
+        assert.calledOnce(requestMock);
+    });
+
+    it('should make a GraphQL mutation', async () => {
+        const mutation = `
+            mutation {
+                addWebhook(input: {
+                    url: "https://example.com/webhook",
+                    secret: "mysecret"
+                }) {
+                    id
+                    url
+                    secret
+                }
+            }
+        `;
+
+        const expectedResponse = {
+            body: {
+                data: {
+                    addWebhook: {
+                        id: 3,
+                        url: 'https://example.com/webhook',
+                        secret: 'mysecret'
+                    }
+                }
+            }
+        };
+
+        requestMock.resolves(expectedResponse);
+
+        const response = await client.mutate(mutation);
+
+        assert.ok(response);
+        assert.ok(response.data);
+        assert.ok(response.data.addWebhook);
+        assert.strictEqual(response.data.addWebhook.id, 3);
+        assert.strictEqual(response.data.addWebhook.url, 'https://example.com/webhook');
+        assert.strictEqual(response.data.addWebhook.secret, 'mysecret');
+        assert.calledOnce(requestMock);
+    });
+});

--- a/test/sd-graphql.test.js
+++ b/test/sd-graphql.test.js
@@ -33,8 +33,8 @@ describe('SDGraphQLClient', () => {
     it('should make a GraphQL query', async () => {
         // Test making a GraphQL query using SDGraphQLClient
         const query = `
-            query GetUser($username: String!) {
-                user(login: $username) {
+            query GetUser($login: String!) {
+                user(login: $login) {
                     name
                     email
                     login
@@ -43,7 +43,7 @@ describe('SDGraphQLClient', () => {
         `;
 
         const variables = {
-            username: 'ai_humanoid'
+            login: 'ai_humanoid'
         };
 
         const expectedResponse = {


### PR DESCRIPTION
## Context

We need to interact with github GraphQL API to get info on enterprise users

## Objective

This PR adds functions to interact with Github Graph QL API

## References
https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/queries

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
