### PR TITLE
feat: update EAU query

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,17 +28,22 @@ class GithubScmGraphQL {
 
         const { data } = await this.sdGql.query({
             query: queries.GetEnterpriseUserAccount,
-            variables: { slug, query: login },
+            variables: { login },
             token
         });
 
-        if (data && data.enterprise) {
-            const { members } = data.enterprise;
+        if (data && data.user && data.user.enterprises) {
+            const { totalCount, nodes, pageInfo } = data.user.enterprises;
 
-            if (members && members.totalCount === 1) {
-                return {
-                    type: 'EnterpriseUserAccount'
-                };
+            if (nodes && totalCount > 0 && pageInfo.hasNextPage === false) {
+                const enterprise = nodes.find(node => node.slug === slug);
+
+                if (enterprise) {
+                    return {
+                        login,
+                        type: 'EnterpriseUserAccount'
+                    };
+                }
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ class GithubScmGraphQL {
             const { members } = data.enterprise;
 
             if (members && members.totalCount === 1) {
-                return members.nodes[0];
+                return {
+                    type: 'EnterpriseUserAccount'
+                };
             }
         }
 

--- a/queries.js
+++ b/queries.js
@@ -3,12 +3,22 @@
 const gql = require('graphql-tag');
 
 module.exports.GetEnterpriseUserAccount = gql`
-    query GetEnterpriseUserAccount($slug: String!, $query: String!) {
-        enterprise(slug: $slug) {
+    query GetEnterpriseUserAccount($login: String!) {
+        user(login: $login) {
             name
             id
-            members(query: $query, first: 1) {
+            login
+            enterprises(first: 100) {
                 totalCount
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    id
+                    name
+                    slug
+                }
             }
         }
     }

--- a/queries.js
+++ b/queries.js
@@ -9,24 +9,12 @@ module.exports.GetEnterpriseUserAccount = gql`
             id
             members(query: $query, first: 1) {
                 totalCount
-                nodes {
-                    type: __typename
-                    ... on EnterpriseUserAccount {
-                        id
-                        name
-                        login
-                    }
-                    ... on User {
-                        id
-                        name
-                        login
-                    }
-                }
             }
         }
     }
 `;
 
+// needs `admin:enterprise` scope for EAU fragment
 module.exports.ListEnterpriseMembers = gql`
     query ListEnterpriseMembers($slug: String!, $cursor: String) {
         enterprise(slug: $slug) {

--- a/queries.js
+++ b/queries.js
@@ -7,7 +7,7 @@ module.exports.GetEnterpriseUserAccount = gql`
         enterprise(slug: $slug) {
             name
             id
-            members(query: $query, first: 1, role: MEMBER) {
+            members(query: $query, first: 1) {
                 totalCount
                 nodes {
                     type: __typename

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,7 +77,9 @@ describe('GithubGraphQL', () => {
             token
         });
 
-        assert.deepEqual(result, data.enterprise.members.nodes[0]);
+        assert.deepEqual(result, {
+            type: 'EnterpriseUserAccount'
+        });
         assert.calledWith(githubGql.sdGql.query, {
             query: queries.GetEnterpriseUserAccount,
             variables: { slug, query: login },


### PR DESCRIPTION
## Context

Update GQL EAU query to account for MEMBERS and OWNERS in enterprise
Remove fragment that needs `admin` scope

## Objective

Update GQL EAU query to account for MEMBERS and OWNERS

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
