### PR TITLE
fix: move rewiremock to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Pritam Paul <pritamstyz4ever@gmail.com>",
   "contributors": [],
   "devDependencies": {
+    "rewiremock": "^3.14.5",
     "chai": "^4.3.6",
     "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
@@ -31,7 +32,6 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "rewiremock": "^3.14.5",
     "screwdriver-request": "^2.0.1"
   },
   "release": {


### PR DESCRIPTION
## Context
`rewiremock` includes `lodash.template`, which has vulnerabilities and is flagged by the vulnerability analysis tool.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Since `rewiremock` is only used for testing, we move it to `devDependencies`. 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://security.snyk.io/vuln/SNYK-JS-LODASHTEMPLATE-1088054
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
